### PR TITLE
automatic backup of old config after plugin update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.theagent'
-version = '1.0.0'
+version = '1.0.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/theagent/tinyLobby/ConfigurationManager.java
+++ b/src/main/java/com/theagent/tinyLobby/ConfigurationManager.java
@@ -1,10 +1,12 @@
 package com.theagent.tinyLobby;
 
-import io.papermc.paper.annotation.DoNotUse;
 import net.kyori.adventure.text.Component;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
+import org.jetbrains.annotations.ApiStatus;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -12,18 +14,95 @@ import java.util.Set;
 public class ConfigurationManager {
 
     private final TinyLobby plugin;
-    private final FileConfiguration config;
+    private FileConfiguration config;
+    private int wasUpdated;
 
     public ConfigurationManager(TinyLobby plugin) {
         this.plugin = plugin;
-        this.plugin.saveDefaultConfig(); // save default config if nonexistent
+
+        createConfig();
+
+        wasUpdated = checkOutdatedConfig() ? 3 : 0;
+    }
+
+    /**
+     * Check if the currently saved config was made for an older version of the plugin
+     * and if so, backup the old one and create the new updated config
+     */
+    private boolean checkOutdatedConfig() {
+        String[][] versions = new String[2][3];
+        versions[0] = plugin.getPluginMeta().getVersion().split("\\.");
+        versions[1] = config.getString("plugin-version", "").split("\\.");
+
+        if (versions[1].length != 3) {
+            plugin.logger.info("Outdated config found! Creating backup...");
+            backupOldConfig();
+
+            return true;
+        }
+
+        for (int i = 0; i < 3; i++) {
+            if (isOlder(versions, i)) {
+                plugin.logger.info("Outdated config found! Creating backup...");
+                backupOldConfig();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Parses the version string to int and compares if one part of the version number
+     * inside the config is smaller than the current plugin version
+     *
+     * @param versions Array containing both plugin and config version numbers
+     * @param index    the current part of the version number to be checked
+     * @return if the config version is older than the plugin
+     */
+    private boolean isOlder(String[][] versions, int index) {
+        int pluginVersion = Integer.parseInt(versions[0][index]);
+        int configVersion = Integer.parseInt(versions[1][index]);
+        return pluginVersion > configVersion;
+    }
+
+    /**
+     * Appends the old version number to the outdated config file
+     * and creates a new one
+     */
+    private void backupOldConfig() {
+        Path dataPath = plugin.getDataPath();
+        // rename file
+        File configFile = dataPath.resolve("config.yml").toFile();
+        boolean success = configFile.renameTo(new File(dataPath.resolve(
+                "config-backup-"
+                        + config.getString("plugin-version", "noVersionDefined")
+                        + ".yml"
+        ).toString()));
+
+        // abort after unsuccessful renaming and send a warning
+        if (!success) {
+            plugin.logger.warning("Failed to backup old config!");
+            return;
+        }
+
+        createConfig();
+        plugin.logger.info("Finished creating backup!");
+    }
+
+    /**
+     * Creates a new configuration file if not already present
+     */
+    private void createConfig() {
+        plugin.saveDefaultConfig();
         config = plugin.getConfig();
     }
 
     /**
      * Reloads the config file
      */
-    @DoNotUse
+    @ApiStatus.Experimental
     public void reload() {
         plugin.getConfig();
         plugin.logger.info("Reloaded configuration successfully.");
@@ -82,9 +161,43 @@ public class ConfigurationManager {
         );
     }
 
+    /**
+     * Parses the lore into a usable (Text-)Component
+     *
+     * @param lore single lore line
+     * @return lore as Component
+     */
     private Component parseLore(String lore) {
         // TODO correctly parse formatting codes
         return Component.text(lore);
+    }
+
+    /**
+     * Get if the plugin was updated recently
+     * <p>
+     * Also used to send a warning to a server operator 3 times on join
+     *
+     * @return int > 0 --> recently updated
+     */
+    public int getWasUpdated() {
+        return wasUpdated;
+    }
+
+    /**
+     * Decreases the counter
+     * <p>
+     * Used for showing the warning message 3 times
+     */
+    public void decreaseWasUpdated() {
+        wasUpdated--;
+    }
+
+    /**
+     * Instantly reset the counter to 0
+     */
+    public void resetWasUpdated() {
+        wasUpdated = 0;
+        // TODO reset the counter to 0 when admin reloads config (via reload command?)
     }
 
 }

--- a/src/main/java/com/theagent/tinyLobby/PlayerListener.java
+++ b/src/main/java/com/theagent/tinyLobby/PlayerListener.java
@@ -1,0 +1,34 @@
+package com.theagent.tinyLobby;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+public class PlayerListener implements Listener {
+
+    private final ConfigurationManager config;
+
+    public PlayerListener(ConfigurationManager config) {
+        this.config = config;
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        // check if the player is an Op and if the plugin was recently updated
+        if (player.isOp() && config.getWasUpdated() > 0) {
+            player.sendMessage(
+                    TinyLobby.MESSAGE_PREFIX.append(Component.text(
+                            "TinyLobby was updated, you should reconfigure the plugin config!",
+                            NamedTextColor.GOLD
+                    ))
+            );
+            // decrease counter lowering the amount of times the message will be shown
+            config.decreaseWasUpdated();
+        }
+    }
+
+}

--- a/src/main/java/com/theagent/tinyLobby/TinyLobby.java
+++ b/src/main/java/com/theagent/tinyLobby/TinyLobby.java
@@ -34,6 +34,14 @@ public final class TinyLobby extends JavaPlugin {
         registerPluginChannels();
 
         logger.info("TinyLobby plugin enabled");
+
+        // if the plugin was recently updated, send a warning to the console
+        if (configManager.getWasUpdated() > 0) {
+            logger.warning(String.format(
+                    "TinyLobby was updated to %s, you should reconfigure the plugin config!",
+                    this.getPluginMeta().getVersion()
+            ));
+        }
     }
 
     /**
@@ -60,6 +68,7 @@ public final class TinyLobby extends JavaPlugin {
     private void registerEvents() {
         getServer().getPluginManager().registerEvents(gui, this);
         getServer().getPluginManager().registerEvents(new EnvironmentController(), this);
+        getServer().getPluginManager().registerEvents(new PlayerListener(configManager), this);
     }
 
     /**
@@ -86,4 +95,5 @@ public final class TinyLobby extends JavaPlugin {
         getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
         PlayerSender.setPlugin(this);
     }
+
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,5 @@
+# Plugin version - do not change!
+plugin-version: "1.0.1"
 # Title of the Server Selector GUI window
 title: "Choose a server:"
 # Message displayed when leaving the server

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,5 +1,5 @@
 name: TinyLobby
-version: '1.0.0'
+version: '1.0.1'
 main: com.theagent.tinyLobby.TinyLobby
 api-version: '1.21.3'
 prefix: TinyLobby


### PR DESCRIPTION
If the plugin notices at startup that the version of the config file is lower than the plugin version, the config file is backed up and replaced by the new config.

The name of the backup would be `config-backup-1.0.0.yml` if the previous version was `1.0.0`.