### PR TITLE
Full void world

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,13 @@ allowing players to select and join servers from a list.
 | Java        |   21    |
 | Minecraft   | 1.21.3  |
 | Server Type | PaperMC |
+
+## Suggested world setup
+
+Set the following properties in `server.properties`:
+
+| Property              | Value                                                                                |
+|-----------------------|--------------------------------------------------------------------------------------|
+| `generate-structures` | `false`                                                                              |
+| `generator-settings`  | `{"biome"\:"minecraft\:plains","layers"\:[{"block"\:"minecraft\:air","height"\:1}]}` |
+| `level-type`          | `minecraft\:flat`                                                                    |

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = 'org.theagent'
-version = '1.1.0'
+version = '1.1.1'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/theagent/tinyLobby/ConfigurationManager.java
+++ b/src/main/java/com/theagent/tinyLobby/ConfigurationManager.java
@@ -182,6 +182,15 @@ public class ConfigurationManager {
     }
 
     /**
+     * Get if players should be blinded
+     *
+     * @return Player should be blind
+     */
+    public boolean getBlindPlayer() {
+        return config.getBoolean("blind-player");
+    }
+
+    /**
      * Get the item which opens the GUI
      *
      * @return item

--- a/src/main/java/com/theagent/tinyLobby/PlayerListener.java
+++ b/src/main/java/com/theagent/tinyLobby/PlayerListener.java
@@ -35,6 +35,9 @@ public class PlayerListener implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
 
+        // hide player join message
+        event.joinMessage(null);
+
         // set flying to true so players don't fall into the void
         player.setAllowFlight(true);
         player.setFlying(true);
@@ -153,6 +156,12 @@ public class PlayerListener implements Listener {
     @EventHandler
     public void onPlayerMove(PlayerMoveEvent event) {
         event.setCancelled(true);
+    }
+
+    @EventHandler
+    public void onPlayerLeave(PlayerQuitEvent event) {
+        // hide player leave message
+        event.quitMessage(null);
     }
 
 }

--- a/src/main/java/com/theagent/tinyLobby/PlayerListener.java
+++ b/src/main/java/com/theagent/tinyLobby/PlayerListener.java
@@ -43,19 +43,23 @@ public class PlayerListener implements Listener {
         player.setFlying(true);
 
         // blind player to hide world
-        player.addPotionEffect(new PotionEffect(
-                PotionEffectType.BLINDNESS,
-                PotionEffect.INFINITE_DURATION,
-                255,
-                false,
-                false));
-        player.addPotionEffect(new PotionEffect(
-                PotionEffectType.INVISIBILITY,
-                PotionEffect.INFINITE_DURATION,
-                255,
-                false,
-                false
-        ));
+        if (config.getBlindPlayer()) {
+            player.addPotionEffect(new PotionEffect(
+                    PotionEffectType.BLINDNESS,
+                    PotionEffect.INFINITE_DURATION,
+                    255,
+                    false,
+                    false));
+            player.addPotionEffect(new PotionEffect(
+                    PotionEffectType.INVISIBILITY,
+                    PotionEffect.INFINITE_DURATION,
+                    255,
+                    false,
+                    false
+            ));
+        } else {
+            player.removePotionEffect(PotionEffectType.BLINDNESS);
+        }
 
         // check if the player is an Op and if the plugin was recently updated
         if (player.isOp() && config.getWasUpdated() > 0) {

--- a/src/main/java/com/theagent/tinyLobby/PlayerListener.java
+++ b/src/main/java/com/theagent/tinyLobby/PlayerListener.java
@@ -10,6 +10,8 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 import java.util.Objects;
 
@@ -32,6 +34,26 @@ public class PlayerListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
+
+        // set flying to true so players don't fall into the void
+        player.setAllowFlight(true);
+        player.setFlying(true);
+
+        // blind player to hide world
+        player.addPotionEffect(new PotionEffect(
+                PotionEffectType.BLINDNESS,
+                PotionEffect.INFINITE_DURATION,
+                255,
+                false,
+                false));
+        player.addPotionEffect(new PotionEffect(
+                PotionEffectType.INVISIBILITY,
+                PotionEffect.INFINITE_DURATION,
+                255,
+                false,
+                false
+        ));
+
         // check if the player is an Op and if the plugin was recently updated
         if (player.isOp() && config.getWasUpdated() > 0) {
             player.sendMessage(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,8 @@ plugin-version: "1.1.0"
 title: "Choose a server:"
 # Size of the GUI (valid sizes: 54 (double chest), 27 (single chest))
 gui-size: 54
+# Blinds player to hide world
+blind-player: true
 # Allow players to close the GUI
 allow-closing: false
 # Inventory item that opens the GUI (deactivated if 'allow-closing' is false)

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Plugin version - do not change!
-plugin-version: "1.1.0"
+plugin-version: "1.1.1"
 # Title of the Server Selector GUI window
 title: "Choose a server:"
 # Size of the GUI (valid sizes: 54 (double chest), 27 (single chest))

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,5 +1,5 @@
 name: TinyLobby
-version: '1.1.0'
+version: '1.1.1'
 main: com.theagent.tinyLobby.TinyLobby
 api-version: '1.21.3'
 prefix: TinyLobby


### PR DESCRIPTION
Players are now blind by default when inside the lobby. This allows using a void world to increase performance.
Additionally, join and leave messages are hidden.